### PR TITLE
Fix error output on missing uriparser lib

### DIFF
--- a/ext/uriparser_ext/extconf.rb
+++ b/ext/uriparser_ext/extconf.rb
@@ -4,8 +4,7 @@ require 'mkmf'
 require 'rbconfig'
 
 unless have_library('uriparser')
-  error 'You need to install uriparser lib'
-  exit
+  abort "-----\nERROR: You need to install uriparser lib.\n-----"
 end
 
 create_makefile 'uriparser_ext'

--- a/ext/uriparser_ext/extconf.rb
+++ b/ext/uriparser_ext/extconf.rb
@@ -3,6 +3,6 @@
 require 'mkmf'
 require 'rbconfig'
 
-abort "-----\nERROR: You need to install uriparser lib.\n-----" unless have_library('uriparser')
+have_library('uriparser') || abort("-----\nERROR: You need to install uriparser lib.\n-----")
 
 create_makefile 'uriparser_ext'

--- a/ext/uriparser_ext/extconf.rb
+++ b/ext/uriparser_ext/extconf.rb
@@ -3,8 +3,6 @@
 require 'mkmf'
 require 'rbconfig'
 
-unless have_library('uriparser')
-  abort "-----\nERROR: You need to install uriparser lib.\n-----"
-end
+abort "-----\nERROR: You need to install uriparser lib.\n-----" unless have_library('uriparser')
 
 create_makefile 'uriparser_ext'


### PR DESCRIPTION
When trying to install the gem in Ruby 2.7.2, I got this error:
```
extconf.rb:7:in `<main>': undefined method `error' for main:Object (NoMethodError)
```

This happens because `error` is not a valid method in the context of `extconf.rb`.

This PR uses `abort` to convey the same error.
I've also added more spacing around the error message, to make it clear that this is problematic symptom. It's normally quite hard to find the message amongst the verbose failure output.

This is what it looks like now:

```
...
1ed9ll.rb extconf.rb
checking for -luriparser... no
-----
ERROR: You need to install uriparser lib.
-----
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
...
```